### PR TITLE
Lower case the inclued seems to work 

### DIFF
--- a/lib/android-adb/Adb.rb
+++ b/lib/android-adb/Adb.rb
@@ -2,8 +2,8 @@
 # Copyright:: Copyright (c) 2011 Nic Strong
 # License::   MIT (See LICENSE)
 
-require 'Open3'
-require 'Platform'
+require 'open3'
+require 'platform'
 
 module AndroidAdb
 


### PR DESCRIPTION
on 
Linux acsia 2.6.38-11-generic #47-Ubuntu SMP Fri Jul 15 19:27:09 UTC 2011 x86_64 x86_64 x86_64 GNU/Linux

rvm ruby-1.9.2-p136, I get:

LoadError: no such file to load -- Open3

require 'open3'
require 'platform'

seems to solve this
