### PR TITLE
Executing 'which adb' only if current OS is not windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pkg
 examples/t.rb
 .DS_Store
 
+.idea

--- a/android-adb.gemspec
+++ b/android-adb.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{android-adb}
-  s.version = "0.0.5"
+  s.version = "0.0.6.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Nic Strong"]

--- a/lib/android-adb/Adb.rb
+++ b/lib/android-adb/Adb.rb
@@ -121,10 +121,12 @@ module AndroidAdb
     end
 
     def self.find_adb
-      begin
-        which_adb = `which adb`.strip
-        return which_adb if !which_adb.nil? && !which_adb.empty?
-      rescue
+      if (Platform::OS != :win32)
+        begin
+          which_adb = `which adb`.strip
+          return which_adb if !which_adb.nil? && !which_adb.empty?
+        rescue
+        end
       end
       android_home = ENV['ANDROID_HOME']
       if !android_home.nil? && !android_home.empty?

--- a/lib/android-adb/version.rb
+++ b/lib/android-adb/version.rb
@@ -3,7 +3,7 @@ module AndroidAdb
     MAJOR = 0
     MINOR = 0
     PATCH = 6
-    BUILD = nil
+    BUILD = 1
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
   end


### PR DESCRIPTION
While running the Gem on Windows OS, it used to not find command 'which' and was displaying error on console. The change was to execute which command only if current OS was not Windows.
